### PR TITLE
Use strict checks for mutations

### DIFF
--- a/src/ApplyMutation.php
+++ b/src/ApplyMutation.php
@@ -64,12 +64,12 @@ final class ApplyMutation extends NodeVisitorAbstract
             public function leaveNode(Node $node)
             {
                 // If we visit the original node, then replace it with the mutated node
-                if ($node == $this->mutation->original()) {
+                if ($node === $this->mutation->original()) {
                     return $this->mutation->mutation();
                 }
 
                 // If we visit the mutated node, then replace it with the original node
-                if ($node == $this->mutation->mutation()) {
+                if ($node === $this->mutation->mutation()) {
                     return $this->mutation->original();
                 }
             }
@@ -80,7 +80,7 @@ final class ApplyMutation extends NodeVisitorAbstract
              */
             public function enterNode(Node $node)
             {
-                if ($node == $this->mutation->original() || $node == $this->mutation->mutation()) {
+                if ($node === $this->mutation->original() || $node === $this->mutation->mutation()) {
                     return NodeTraverserInterface::DONT_TRAVERSE_CHILDREN;
                 }
             }

--- a/tests/MutateSourceCodeTest.php
+++ b/tests/MutateSourceCodeTest.php
@@ -39,6 +39,22 @@ class MutationSourceCodeTest extends TestCase
         ], $this->results);
     }
 
+    /** @test */
+    function it_should_not_swap_actual_code_with_mutations()
+    {
+        $source = "<?php echo 2 / 2 + 2 * 2;";
+
+        $mutate = new MutateSourceCode(
+            new Multiplication
+        );
+
+        $mutate->mutate($source, $this->storeAppliedMutations());
+
+        $this->assertEquals([
+            'echo 2 / 2 + 2 / 2;',
+        ], $this->results);
+    }
+
     /**
      * Saves the pretty printed mutated AST into the $results property
      */


### PR DESCRIPTION
Fixes the issue where actual code is seen as a mutation of a different node and hence replaced by some other source code.

Using the Multiplication operator:

```
2 / 2 + 2 * 2
```

should mutate to

```
2 / 2 + 2 / 2
```

rather than

```
2 * 2 + 2 / 2
```
